### PR TITLE
Fixing Error in CSV File Writer

### DIFF
--- a/src/data_access/FileTaskDataAccessObject.java
+++ b/src/data_access/FileTaskDataAccessObject.java
@@ -73,7 +73,7 @@ public class FileTaskDataAccessObject implements CreateTaskDataAccessInterface, 
             writer.newLine();
 
             for (TaskI task : tasks.values()) {
-                String line = String.format("%s,%s,%s",
+                String line = String.format("%s,%s",
                         task.getName(), task.getComplete());
                 writer.write(line);
                 writer.newLine();


### PR DESCRIPTION
This is a small yet important fix so I wanted to push those code immediately. I deleted an extra %s from the String.format in the writer in the FileTaskDataAccessObject class to stop an error from occurring.