### PR TITLE
Changing Strategy for the Display Task Use Case

### DIFF
--- a/src/data_access/FileTaskDataAccessObject.java
+++ b/src/data_access/FileTaskDataAccessObject.java
@@ -7,6 +7,7 @@ import entity.TaskI;
 import use_case.complete_task.CompleteTaskDataAccessInterface;
 import use_case.create_task.CreateTaskDataAccessInterface;
 import use_case.delete_task.*;
+import use_case.display_task.DisplayTaskDataAccessInterface;
 
 import java.io.*;
 import java.time.LocalDateTime;
@@ -16,7 +17,7 @@ import java.util.Map;
 
 import static java.lang.Boolean.parseBoolean;
 
-public class FileTaskDataAccessObject implements CreateTaskDataAccessInterface, CompleteTaskDataAccessInterface{
+public class FileTaskDataAccessObject implements CreateTaskDataAccessInterface, CompleteTaskDataAccessInterface, DisplayTaskDataAccessInterface {
     private final File csvFile;
 
     private final Map<String, Integer> headers = new LinkedHashMap<>();
@@ -62,6 +63,11 @@ public class FileTaskDataAccessObject implements CreateTaskDataAccessInterface, 
     public void save(TaskI task) {
         tasks.put(task.getName(), task);
         this.save();
+    }
+
+    @Override
+    public Map<String, TaskI> getAllTasks() {
+        return tasks;
     }
 
     public void save() {

--- a/src/interface_adapter/display_task/DisplayTaskPresenter.java
+++ b/src/interface_adapter/display_task/DisplayTaskPresenter.java
@@ -19,7 +19,7 @@ public class DisplayTaskPresenter implements DisplayTaskOutputBoundary {
 
         DisplayTaskState displayTaskState = displayTaskViewModel.getState();
         displayTaskState.setTasks(response.getAllTasks());
-        displayTaskState.setTaskNames(response.getTaskNames());
+//        displayTaskState.setTaskNames(response.getTaskNames());
         this.displayTaskViewModel.setState(displayTaskState);
         displayTaskViewModel.firePropertyChanged();
 

--- a/src/interface_adapter/display_task/DisplayTaskState.java
+++ b/src/interface_adapter/display_task/DisplayTaskState.java
@@ -5,11 +5,12 @@ import java.util.Set;
 public class DisplayTaskState {
 
     private Set<String> tasks = null;
-    private String taskNames = null;
+
+    private Set<Boolean> completions = null;
 
     public DisplayTaskState(DisplayTaskState copy) {
         this.tasks = copy.tasks;
-        this.taskNames = copy.taskNames;
+        this.completions = copy.completions;
     }
 
     public DisplayTaskState() {
@@ -19,12 +20,12 @@ public class DisplayTaskState {
 
     public void setTasks(Set<String> tasks) {this.tasks = tasks;}
 
-    public String getTaskNames() {
-        return taskNames;
+    public Set<Boolean> getCompletions() {
+        return completions;
     }
 
-    public void setTaskNames(String taskNames) {
-        this.taskNames = taskNames;
+    public void setCompletions(Set<Boolean> completions) {
+        this.completions = completions;
     }
 
 }

--- a/src/use_case/display_task/DisplayTaskDataAccessInterface.java
+++ b/src/use_case/display_task/DisplayTaskDataAccessInterface.java
@@ -5,11 +5,9 @@ import entity.TaskI;
 import java.util.Map;
 
 public interface DisplayTaskDataAccessInterface {
-    void display(Map<String, TaskI> prevTasks);
 
     Map<String, TaskI> getAllTasks();
 
-    void save();
 
 
 }

--- a/src/use_case/display_task/DisplayTaskDataAccessInterface.java
+++ b/src/use_case/display_task/DisplayTaskDataAccessInterface.java
@@ -8,6 +8,4 @@ public interface DisplayTaskDataAccessInterface {
 
     Map<String, TaskI> getAllTasks();
 
-
-
 }

--- a/src/use_case/display_task/DisplayTaskInteractor.java
+++ b/src/use_case/display_task/DisplayTaskInteractor.java
@@ -16,11 +16,12 @@ public class DisplayTaskInteractor {
     }
 
     public void execute() {
-        DisplayTaskOutputData displayTaskOutputData = new DisplayTaskOutputData(displayDataAccessObject.getAllTasks().keySet(), String.join(",", displayDataAccessObject.getAllTasks().keySet()), false);
-        displayDataAccessObject.display(displayDataAccessObject.getAllTasks());
-        displayDataAccessObject.save();
-        taskPresenter.prepareSuccessView(displayTaskOutputData);
 
+//        for displayDataAccessObject.getAllTasks().entrySet()
+
+
+//        DisplayTaskOutputData displayTaskOutputData = new DisplayTaskOutputData(displayDataAccessObject.getAllTasks().keySet(), displayDataAccessObject.getAllTasks().entrySet(), false);
+//        taskPresenter.prepareSuccessView(displayTaskOutputData);
     }
 
 }

--- a/src/use_case/display_task/DisplayTaskOutputData.java
+++ b/src/use_case/display_task/DisplayTaskOutputData.java
@@ -5,24 +5,20 @@ import java.util.Set;
 public class DisplayTaskOutputData {
 
     private final Set<String> tasks;
-    private String taskNames;
+    private final Set<Boolean> completions;
 
     private boolean useCaseFailed;
 
-    public DisplayTaskOutputData(Set<String> tasks, String taskNames, boolean useCaseFailed) {
+    public DisplayTaskOutputData(Set<String> tasks, Set<Boolean> completions, boolean useCaseFailed) {
         this.tasks = tasks;
-        this.taskNames = taskNames;
+        this.completions = completions;
         this.useCaseFailed = useCaseFailed;
     }
 
     public Set<String> getAllTasks() {return tasks;}
 
-    public String getTaskNames() {
-        return taskNames;
-    }
-
-    public void setTaskNames(String taskNames) {
-        this.taskNames = taskNames;
+    public Set<Boolean> getCompletions() {
+        return completions;
     }
 
 

--- a/src/view/TaskView.java
+++ b/src/view/TaskView.java
@@ -8,6 +8,7 @@ import interface_adapter.create_task.CreateTaskState;
 import interface_adapter.create_task.CreateTaskViewModel;
 
 import interface_adapter.display_task.DisplayTaskController;
+import interface_adapter.display_task.DisplayTaskState;
 import interface_adapter.display_task.DisplayTaskViewModel;
 
 import javax.swing.*;
@@ -138,6 +139,7 @@ public class TaskView extends JPanel implements ActionListener, PropertyChangeLi
 
         TaskView.this.displayTaskController.execute(); //Display all the existing tasks in the CSV
 
+
     }
 
     @Override
@@ -147,6 +149,12 @@ public class TaskView extends JPanel implements ActionListener, PropertyChangeLi
 
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
+        if (evt.getPropertyName().equals("display")) {
+            DisplayTaskState state = (DisplayTaskState) evt.getNewValue();
+//            for (String task : gfg.keySet()) {
+//
+//            }
+        }
     }
 
 }


### PR DESCRIPTION
Various classes regarding the Display Task Use Case were changed to accommodate a different strategy to display all the tasks. I am trying to send a set of completions along side a set of task names so that the Task View can display the existing tasks.