### PR TITLE
Changing from Sets to ArrayLists in the Display Task Use Case

### DIFF
--- a/src/data_access/FileTaskDataAccessObject.java
+++ b/src/data_access/FileTaskDataAccessObject.java
@@ -6,14 +6,10 @@ import entity.TaskFactory;
 import entity.TaskI;
 import use_case.complete_task.CompleteTaskDataAccessInterface;
 import use_case.create_task.CreateTaskDataAccessInterface;
-import use_case.delete_task.*;
 import use_case.display_task.DisplayTaskDataAccessInterface;
 
 import java.io.*;
-import java.time.LocalDateTime;
 import java.util.*;
-
-import static java.lang.Boolean.parseBoolean;
 
 public class FileTaskDataAccessObject implements CreateTaskDataAccessInterface, CompleteTaskDataAccessInterface, DisplayTaskDataAccessInterface {
     private final File csvFile;
@@ -47,7 +43,8 @@ public class FileTaskDataAccessObject implements CreateTaskDataAccessInterface, 
                     String[] col = row.split(",");
                     String nameTask = String.valueOf(col[headers.get("task_name")]);
                     String completionTask = String.valueOf(col[headers.get("completion")]);
-                    TaskI task = taskFactory.create(nameTask, parseBoolean(completionTask));
+                    boolean complete = Boolean.parseBoolean(completionTask);
+                    TaskI task = taskFactory.create(nameTask, complete);
                     tasks.put(nameTask, task);
                 }
             }
@@ -64,11 +61,11 @@ public class FileTaskDataAccessObject implements CreateTaskDataAccessInterface, 
     }
 
     @Override
-    public Map<String, Set<Object>> getAllTasks() {
-        Map<String, Set<Object>> retTask = new HashMap<>();
+    public Map<String, ArrayList<Object>> getAllTasks() {
+        Map<String, ArrayList<Object>> retTask = new LinkedHashMap<>();
 
         for (TaskI task: tasks.values()) {
-            Set<Object> taskInfo = new HashSet<>();
+            ArrayList<Object> taskInfo = new ArrayList<>();
             taskInfo.add(task.getComplete());
             retTask.put(task.getName(), taskInfo);
         }

--- a/src/interface_adapter/display_task/DisplayTaskState.java
+++ b/src/interface_adapter/display_task/DisplayTaskState.java
@@ -1,13 +1,12 @@
 package interface_adapter.display_task;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
 
 public class DisplayTaskState {
 
-    private Set<String> tasks = new HashSet<>();
+    private ArrayList<String> tasks = new ArrayList<>();
 
-    private Set<Object> taskInfo = new HashSet<>();
+    private ArrayList<ArrayList<Object>> taskInfo = new ArrayList<>();
 
     public DisplayTaskState(DisplayTaskState copy) {
         this.tasks = copy.tasks;
@@ -17,15 +16,15 @@ public class DisplayTaskState {
     public DisplayTaskState() {
     }
 
-    public Set<String> getTasks() {return tasks;}
+    public ArrayList<String> getTasks() {return tasks;}
 
-    public void setTasks(Set<String> tasks) {this.tasks = tasks;}
+    public void setTasks(ArrayList<String> tasks) {this.tasks = tasks;}
 
-    public Set<Object> getTaskInfo() {
+    public ArrayList<ArrayList<Object>> getTaskInfo() {
         return taskInfo;
     }
 
-    public void setTaskInfo(Set<Object> taskInfo) {
+    public void setTaskInfo(ArrayList<ArrayList<Object>> taskInfo) {
         this.taskInfo = taskInfo;
     }
 

--- a/src/use_case/display_task/DisplayTaskDataAccessInterface.java
+++ b/src/use_case/display_task/DisplayTaskDataAccessInterface.java
@@ -1,12 +1,10 @@
 package use_case.display_task;
 
-import entity.TaskI;
-
+import java.util.ArrayList;
 import java.util.Map;
-import java.util.Set;
 
 public interface DisplayTaskDataAccessInterface {
 
-    Map<String, Set<Object>> getAllTasks();
+    Map<String, ArrayList<Object>> getAllTasks();
 
 }

--- a/src/use_case/display_task/DisplayTaskInteractor.java
+++ b/src/use_case/display_task/DisplayTaskInteractor.java
@@ -1,6 +1,9 @@
 package use_case.display_task;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Collectors;
 
 public class DisplayTaskInteractor {
 
@@ -18,8 +21,7 @@ public class DisplayTaskInteractor {
     }
 
     public void execute() {
-
-        DisplayTaskOutputData displayTaskOutputData = new DisplayTaskOutputData(displayDataAccessObject.getAllTasks().keySet(), Collections.singleton(displayDataAccessObject.getAllTasks().values()), false);
+        DisplayTaskOutputData displayTaskOutputData = new DisplayTaskOutputData(new ArrayList<String>(displayDataAccessObject.getAllTasks().keySet()), new ArrayList<ArrayList<Object>>(displayDataAccessObject.getAllTasks().values()), false);
         taskPresenter.prepareSuccessView(displayTaskOutputData);
     }
 

--- a/src/use_case/display_task/DisplayTaskOutputData.java
+++ b/src/use_case/display_task/DisplayTaskOutputData.java
@@ -1,23 +1,24 @@
 package use_case.display_task;
 
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class DisplayTaskOutputData {
 
-    private final Set<String> tasks;
-    private final Set<Object> taskInfo;
+    private final ArrayList<String> tasks;
+    private final ArrayList<ArrayList<Object>> taskInfo;
 
     private boolean useCaseFailed;
 
-    public DisplayTaskOutputData(Set<String> tasks, Set<Object> taskInfo, boolean useCaseFailed) {
+    public DisplayTaskOutputData(ArrayList<String> tasks, ArrayList<ArrayList<Object>> taskInfo, boolean useCaseFailed) {
         this.tasks = tasks;
         this.taskInfo = taskInfo;
         this.useCaseFailed = useCaseFailed;
     }
 
-    public Set<String> getAllTasks() {return tasks;}
+    public ArrayList<String> getAllTasks() {return tasks;}
 
-    public Set<Object> getTaskInfo() {
+    public ArrayList<ArrayList<Object>> getTaskInfo() {
         return taskInfo;
     }
 

--- a/src/view/TaskView.java
+++ b/src/view/TaskView.java
@@ -185,15 +185,20 @@ public class TaskView extends JPanel implements ActionListener, PropertyChangeLi
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals("display")) {
             DisplayTaskState state = (DisplayTaskState) evt.getNewValue();
-            for (String task: state.getTasks()) {
+            for (int i = 0; i < state.getTasks().size(); i++) {
+                //String task: state.getTasks()
                 JPanel newTask = new JPanel();
                 newTask.setLayout(new FlowLayout(FlowLayout.LEFT));
-                JLabel newTaskText = new JLabel(task);
+                JLabel newTaskText = new JLabel(state.getTasks().get(i));
                 JCheckBox check = new JCheckBox();
 
-//                if ((Boolean) state.getTaskInfo() == true) {
-//                    check.setSelected(true);
-//                }
+                boolean complete = Boolean.parseBoolean(state.getTaskInfo().get(i).get(0).toString());
+
+                if (complete) {
+                    check.setSelected(true);
+                }
+                System.out.println(state.getTaskInfo().get(0).get(0));
+//                System.out.println(state.getTaskInfo().get(i).get(0).toString());
 
                 newTask.add(check);
                 newTask.add(newTaskText);


### PR DESCRIPTION
I changed all instances of sets to arraylists for the display task use case. This is due to the fact that sets do not maintain the order of elements. As such, I switched to arraylists to ensure order is kept the same. Also attempted to make checkboxes that were checked before closing stay checked when reopened, however the boolean casting seems to be not working.